### PR TITLE
update beacon to work on darwin

### DIFF
--- a/example/beacon.go
+++ b/example/beacon.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"runtime"
 
 	"github.com/paypal/gatt"
 	"github.com/paypal/gatt/examples/option"

--- a/example/beacon.go
+++ b/example/beacon.go
@@ -28,7 +28,9 @@ func main() {
 
 	// Advertise as an Eddystone beacon
 	a := &gatt.AdvPacket{}
-	a.AppendFlags(advFlagGeneralDiscoverable | advFlagLEOnly)
+	if runtime.GOOS != "darwin" { // flag not set if darwin
+		a.AppendFlags(advFlagGeneralDiscoverable | advFlagLEOnly)
+	}
 	a.AppendField(advTypeAllUUID16, eddystone.SvcUUIDBytes)
 	a.AppendField(advTypeServiceData16, append(eddystone.SvcUUIDBytes, f...))
 


### PR DESCRIPTION
I implement device.Advertise on darwin and send [PR](https://github.com/paypal/gatt/pull/52) to gatt/paypal. With this PR and removing flags, go_eddystone works on my darwin environment.

In all honesty, I don't know why Flag is not required for darwin. But other implementation(node-eddystone-beacon) [removes first 3 bytes](https://github.com/don/node-eddystone-beacon/blob/master/lib/beacon.js#L127). And it works.
