### PR TITLE
Expose parse API

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -1,0 +1,46 @@
+package eddystone
+
+import "encoding/hex"
+
+type EddystoneType string
+
+const (
+	EddystoneTypeUnknown EddystoneType = ""
+	EddystoneTypeURL                   = "url"
+	EddystoneTypeTLM                   = "tlm"
+	EddystoneTypeUID                   = "uid"
+)
+
+func ParseType(frames []byte) EddystoneType {
+	switch frameType(frames[0]) {
+	case ftUID:
+		return EddystoneTypeUID
+	case ftTLM:
+		return EddystoneTypeTLM
+	case ftURL:
+		return EddystoneTypeURL
+	}
+	return EddystoneTypeUnknown
+}
+
+func ParseUIDFrame(f []byte) (ns, instance string, txPower int) {
+	return hex.EncodeToString(f[2 : 2+10]),
+		hex.EncodeToString(f[12 : 12+6]),
+		byteToInt(f[1])
+}
+
+func ParseURLFrame(f []byte) (url string, txPower int, err error) {
+	txPower = byteToInt(f[1])
+	url, err = decodeURL(f[2], f[3:])
+	if err != nil {
+		return url, txPower, err
+	}
+	return url, txPower, nil
+}
+
+func ParseTLMFrame(f []byte) (batt uint16, temp float32, advCnt uint32, secCnt uint32) {
+	return bytesToUint16(f[2 : 2+2]),
+		fixTofloat32(bytesToUint16(f[4 : 4+2])),
+		bytesToUint32(f[6 : 6+4]),
+		bytesToUint32(f[10 : 10+4])
+}

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,105 @@
+package eddystone
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestParseType(t *testing.T) {
+
+	frames := []byte{byte(ftUID)}
+	ftype := ParseType(frames)
+	if ftype != EddystoneTypeUID {
+		t.Fatal("Expected type is UID")
+	}
+
+	frames = []byte{byte(ftTLM)}
+	ftype = ParseType(frames)
+	if ftype != EddystoneTypeTLM {
+		t.Fatal("Expected type is TLM")
+	}
+
+	frames = []byte{byte(ftURL)}
+	ftype = ParseType(frames)
+	if ftype != EddystoneTypeURL {
+		t.Fatal("Expected type is URL")
+	}
+
+}
+
+func TestParseUIDFrame(t *testing.T) {
+	namespace := "AAAAAAAAAABBBBBBBBBB"
+	instance := "123456123456"
+	txPwr := 99
+	f, err := MakeUIDFrame(namespace, instance, txPwr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace1, instance1, txPower1 := ParseUIDFrame(f)
+
+	if namespace != strings.ToUpper(namespace1) {
+		t.Fatal("namespace mismatch", namespace, namespace1)
+	}
+	if instance != instance1 {
+		t.Fatal("instance mismatch", instance, instance1)
+	}
+	if txPwr != txPower1 {
+		t.Fatal("txPower mismatch", txPwr, txPower1)
+	}
+
+}
+
+func TestParseTLMFrame(t *testing.T) {
+	var batt uint16 = 10
+	var temp float32 = 30.1
+	var advCnt uint32 = 100
+	var secCnt uint32 = 200
+	f, err := MakeTLMFrame(batt, temp, advCnt, secCnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	batt1, temp1, advCnt1, secCnt1 := ParseTLMFrame(f)
+	if batt != batt1 {
+		t.Fatal("batt mismatch", batt, batt1)
+	}
+
+	tempr := fmt.Sprintf("%.2f", temp)
+	tempr1 := fmt.Sprintf("%.2f", temp1)
+	if tempr != tempr1 {
+		t.Fatal("temp mismatch", temp, temp1)
+	}
+	if advCnt != advCnt1 {
+		t.Fatal("advCnt mismatch", advCnt, advCnt1)
+	}
+	if secCnt != secCnt1 {
+		t.Fatal("secCnt mismatch", secCnt, secCnt1)
+	}
+
+}
+
+func TestParseURLFrame(t *testing.T) {
+
+	url := "https://example.com"
+	txPwr := 99
+
+	f, err := MakeURLFrame(url, txPwr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	url1, txPwr1, err := ParseURLFrame(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if url != url1 {
+		t.Fatal("url mismatch", url, url1)
+	}
+
+	if txPwr != txPwr1 {
+		t.Fatal("txPwr mismatch", txPwr, txPwr1)
+	}
+
+}


### PR DESCRIPTION
Hi
the library has implemented a two way conversion but parsing is not expose. This PR expose four methods to allow parsing eddystone frames

- `ParseType(frames []byte) EddystoneType`
- `ParseUIDFrame(f []byte) (ns, instance string, txPower int)`
- `ParseTLMFrame(f []byte) (batt uint16, temp float32, advCnt uint32, secCnt uint32) `
- `ParseURLFrame(f []byte) (url string, txPower int, err error)`